### PR TITLE
Fix File Permissions of `powershell-bin`

### DIFF
--- a/powershell-bin/PKGBUILD
+++ b/powershell-bin/PKGBUILD
@@ -41,6 +41,7 @@ package() {
 
   install -dm755 "$pkgdir/usr/lib/$_pkgname-$pkgnum"
   cp -a -t "$pkgdir/usr/lib/$_pkgname-$pkgnum" ./*
+  chmod 755 "$pkgdir/usr/lib/$_pkgname-$pkgnum/pwsh";
 
   install -dm755 "$pkgdir/usr/bin"
   ln -s "/usr/lib/$_pkgname-$pkgnum/pwsh" "$pkgdir/usr/bin/pwsh"


### PR DESCRIPTION
The current `.tar.gz` files in the `PowerShell` GitHub releases seem to have the `pwsh` file set to mode `644` now - effectively making the file not executable.

Changes in this PR will make `pwsh` explicitly executable by changing the file mode to `755` after copying the archive contents.